### PR TITLE
Center boundingbox

### DIFF
--- a/Configuration.py
+++ b/Configuration.py
@@ -41,6 +41,7 @@ class Configuration(PyQt5.QtCore.QObject):
 		self._status = UM.Mesh.MeshReader.MeshReader.PreReadResult.failed
 		self._show_ui_trigger.connect(self._prompt)
 		self._height = 0.1
+		self._center_enabled = False
 
 	def prompt(self, file_name) -> UM.Mesh.MeshReader.MeshReader.PreReadResult:
 		"""
@@ -101,6 +102,18 @@ class Configuration(PyQt5.QtCore.QObject):
 	@PyQt5.QtCore.pyqtProperty(float, notify=heightChanged, fset=setHeight)
 	def height(self):
 		return self._height
+
+	centerEnabledChanged = PyQt5.QtCore.pyqtSignal()
+
+	@PyQt5.QtCore.pyqtSlot(int)
+	def setCenterEnabled(self, center_enabled):
+		if center_enabled != self._center_enabled:
+			self._center_enabled = center_enabled
+			self.centerEnabledChanged.emit()
+
+	@PyQt5.QtCore.pyqtProperty(bool, notify=centerEnabledChanged, fset=setCenterEnabled)
+	def centerEnabled(self):
+		return self._center_enabled
 
 	def _prompt(self) -> UM.Mesh.MeshReader.MeshReader.PreReadResult:
 		"""

--- a/ConfigurationDialogue.qml
+++ b/ConfigurationDialogue.qml
@@ -20,6 +20,8 @@ UM.Dialog {
 	onAccepted: manager.confirm()
 
 	Item { //Row for height (mm).
+		id: heightRow
+
 		anchors {
 			left: parent.left
 			right: parent.right
@@ -39,6 +41,28 @@ UM.Dialog {
 			}
 			text: manager.height
 			onEditingFinished: manager.height = text
+		}
+	}
+
+	Item { //Row for center Enabled
+		id: centerRow
+
+		anchors {
+			top: heightRow.bottom
+			left: parent.left
+			right: parent.right
+		}
+		height: childrenRect.height
+
+		Label {
+			text: "Center on buildplate"
+			anchors.verticalCenter: heightField.verticalCenter
+		}
+		CheckBox {
+			id: toggleCenterEnabled
+			anchors.right: parent.right
+	        checked: manager.centerEnabled
+	        onClicked: manager.centerEnabled = checked
 		}
 	}
 

--- a/WriteGCode.py
+++ b/WriteGCode.py
@@ -46,6 +46,23 @@ def sort_commands(commands):
 
 	return sum(segments_sorted, [])
 
+def center_commands(commands, machine_width, machine_depth):
+	# Calculate bounding box
+	min_x = min(command.x for command in commands)
+	max_x = max(command.x for command in commands)
+	min_y = min(command.y for command in commands)
+	max_y = max(command.y for command in commands)
+
+	# Calculate delta relative to build plate dimensions
+	delta_x = (machine_width - (min_x + max_x)) / 2
+	delta_y = (machine_depth - (min_y + max_y)) / 2
+
+	for command in commands:
+		command.x += delta_x
+		command.y += delta_y
+
+	return commands
+
 def write_gcode(config, commands) -> typing.Tuple[str, cura.LayerDataBuilder.LayerDataBuilder]:
 	"""
 	Converts a list of commands into g-code.
@@ -82,6 +99,7 @@ def write_gcode(config, commands) -> typing.Tuple[str, cura.LayerDataBuilder.Lay
 
 	gcodes = []
 	commands = sort_commands(commands)
+	commands = center_commands(commands, machine_width, machine_depth)
 
 	x = 0
 	y = 0

--- a/WriteGCode.py
+++ b/WriteGCode.py
@@ -99,7 +99,9 @@ def write_gcode(config, commands) -> typing.Tuple[str, cura.LayerDataBuilder.Lay
 
 	gcodes = []
 	commands = sort_commands(commands)
-	commands = center_commands(commands, machine_width, machine_depth)
+
+	if(config.centerEnabled):
+		commands = center_commands(commands, machine_width, machine_depth)
 
 	x = 0
 	y = 0


### PR DESCRIPTION
Proof of concept to center toolpath on buildplate. (Added as option in configuration dialog)
Not sure if this is useful for typical users, it is for me.

Note: not tested on printer, but appears to work fine form looking at Cura Preivew